### PR TITLE
UserLoanStatus enum class를 통해서 기존 Boolean 값으로 처리하던 로직을 리팩토링한다

### DIFF
--- a/src/main/kotlin/com/group/libraryapp/domain/user/User.kt
+++ b/src/main/kotlin/com/group/libraryapp/domain/user/User.kt
@@ -29,7 +29,7 @@ class User(
     }
 
     fun loanBook(book: Book) {
-        this.userLoanHistories.add(UserLoanHistory(this, book.name, false))
+        this.userLoanHistories.add(UserLoanHistory.fixture(this, book.name))
     }
 
     fun returnBook(bookName: String) {

--- a/src/main/kotlin/com/group/libraryapp/domain/user/loanhistory/UserLoanHistory.kt
+++ b/src/main/kotlin/com/group/libraryapp/domain/user/loanhistory/UserLoanHistory.kt
@@ -10,7 +10,7 @@ class UserLoanHistory(
 
     val bookName: String,
 
-    var isReturn: Boolean,
+    var status: UserLoanStatus = UserLoanStatus.LOANED,
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -18,7 +18,22 @@ class UserLoanHistory(
 ) {
 
     fun doReturn() {
-        this.isReturn = true
+        this.status = UserLoanStatus.RETURNED
     }
 
+    companion object {
+        fun fixture(
+            user: User,
+            bookName: String = "이상한 나라의 엘리스",
+            status: UserLoanStatus = UserLoanStatus.LOANED,
+            id: Long? = null,
+        ): UserLoanHistory {
+            return UserLoanHistory(
+                user = user,
+                bookName = bookName,
+                status = status,
+                id = id,
+            )
+        }
+    }
 }

--- a/src/main/kotlin/com/group/libraryapp/domain/user/loanhistory/UserLoanHistoryRepository.kt
+++ b/src/main/kotlin/com/group/libraryapp/domain/user/loanhistory/UserLoanHistoryRepository.kt
@@ -4,6 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface UserLoanHistoryRepository : JpaRepository<UserLoanHistory, Long> {
 
-    fun findByBookNameAndIsReturn(bookName: String, isReturn: Boolean): UserLoanHistory?
+    fun findByBookNameAndStatus(bookName: String, status: UserLoanStatus): UserLoanHistory?
 
 }

--- a/src/main/kotlin/com/group/libraryapp/domain/user/loanhistory/UserLoanStatus.kt
+++ b/src/main/kotlin/com/group/libraryapp/domain/user/loanhistory/UserLoanStatus.kt
@@ -1,0 +1,6 @@
+package com.group.libraryapp.domain.user.loanhistory
+
+enum class UserLoanStatus {
+    RETURNED, // 반납 되어 있는 상태
+    LOANED, // 대출 중인 상태
+}

--- a/src/main/kotlin/com/group/libraryapp/service/book/BookService.kt
+++ b/src/main/kotlin/com/group/libraryapp/service/book/BookService.kt
@@ -4,6 +4,7 @@ import com.group.libraryapp.domain.book.Book
 import com.group.libraryapp.domain.book.BookRepository
 import com.group.libraryapp.domain.user.UserRepository
 import com.group.libraryapp.domain.user.loanhistory.UserLoanHistoryRepository
+import com.group.libraryapp.domain.user.loanhistory.UserLoanStatus
 import com.group.libraryapp.dto.book.request.BookLoanRequest
 import com.group.libraryapp.dto.book.request.BookRequest
 import com.group.libraryapp.dto.book.request.BookReturnRequest
@@ -28,7 +29,7 @@ class BookService(
     fun loanBook(request: BookLoanRequest) {
         val book = bookRepository.findByName(request.bookName) ?: fail()
 
-        if (userLoanHistoryRepository.findByBookNameAndIsReturn(request.bookName, false) != null) {
+        if (userLoanHistoryRepository.findByBookNameAndStatus(request.bookName, UserLoanStatus.LOANED) != null) {
             throw IllegalArgumentException("진작 대출되어 있는 책입니다")
         }
 

--- a/src/test/kotlin/com/group/libraryapp/service/book/BookServiceTest.kt
+++ b/src/test/kotlin/com/group/libraryapp/service/book/BookServiceTest.kt
@@ -7,6 +7,7 @@ import com.group.libraryapp.domain.user.User
 import com.group.libraryapp.domain.user.UserRepository
 import com.group.libraryapp.domain.user.loanhistory.UserLoanHistory
 import com.group.libraryapp.domain.user.loanhistory.UserLoanHistoryRepository
+import com.group.libraryapp.domain.user.loanhistory.UserLoanStatus
 import com.group.libraryapp.dto.book.request.BookLoanRequest
 import com.group.libraryapp.dto.book.request.BookRequest
 import com.group.libraryapp.dto.book.request.BookReturnRequest
@@ -66,7 +67,7 @@ class BookServiceTest @Autowired constructor(
         assertThat(results).hasSize(1)
         assertThat(results[0].bookName).isEqualTo("이상한 나라의 앨리스")
         assertThat(results[0].user.id).isEqualTo(savedUser.id)
-        assertThat(results[0].isReturn).isFalse()
+        assertThat(results[0].status).isEqualTo(UserLoanStatus.LOANED)
     }
 
     @Test
@@ -75,7 +76,7 @@ class BookServiceTest @Autowired constructor(
         // given
         bookRepository.save(Book.fixture("이상한 나라의 앨리스"))
         val savedUser = userRepository.save(User("luca", null))
-        userLoanHistoryRepository.save(UserLoanHistory(savedUser, "이상한 나라의 앨리스", false, null))
+        userLoanHistoryRepository.save(UserLoanHistory.fixture(savedUser, "이상한 나라의 앨리스"))
         val request = BookLoanRequest("luca", "이상한 나라의 앨리스")
 
         // when & then
@@ -90,7 +91,7 @@ class BookServiceTest @Autowired constructor(
     fun returnBookTest() {
         // given
         val savedUser = userRepository.save(User("luca", null))
-        userLoanHistoryRepository.save(UserLoanHistory(savedUser, "이상한 나라의 앨리스", false, null))
+        userLoanHistoryRepository.save(UserLoanHistory.fixture(savedUser, "이상한 나라의 앨리스"))
         val request = BookReturnRequest("luca", "이상한 나라의 앨리스")
 
         // when
@@ -99,6 +100,6 @@ class BookServiceTest @Autowired constructor(
         // then
         val results = userLoanHistoryRepository.findAll()
         assertThat(results).hasSize(1)
-        assertThat(results[0].isReturn).isTrue()
+        assertThat(results[0].status).isEqualTo(UserLoanStatus.RETURNED)
     }
 }


### PR DESCRIPTION
1. UserLoanStatus enum class를 통해서 기존 Boolean 값으로 처리하던 로직을 리팩토링한다
2. Boolean 값으로 표현하는 상태 필드가 domain에 너무 많아지면 여러 조합에 대해서 복잡도가 높아져 실수할 가능성이 높아서 리팩토링을 진행한다
3. UserLoanHistoryRepository가 jpa로 사용중인 field가 사라졌는데도 test code를 돌리기 전까지 발견하지 못하는 이슈를 발견했다. 추후 querydsl로 수정할 예정

close #18 